### PR TITLE
fix: scroll position using <ScrollRestoration/> Component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,12 @@ import ContactUs from "./components/ContactUs";
 import About from "./components/About";
 import Error from "./components/Error";
 import MenuPage from "./components/MenuPage";
-import { createBrowserRouter, RouterProvider, Outlet } from "react-router-dom";
+import {
+  createBrowserRouter,
+  RouterProvider,
+  Outlet,
+  ScrollRestoration,
+} from "react-router-dom";
 import Skeleton from "./components/Skeleton";
 
 const Grocery = lazy(() => import("./components/Grocery"));
@@ -14,6 +19,7 @@ const Grocery = lazy(() => import("./components/Grocery"));
 function AppLayout() {
   return (
     <div className="app box-border text-white">
+      <ScrollRestoration />
       <Header />
       <Outlet />
     </div>
@@ -55,5 +61,5 @@ const appRouter = createBrowserRouter([
 ]);
 
 ReactDOM.createRoot(document.getElementById("root")).render(
-    <RouterProvider router={appRouter} />
+  <RouterProvider router={appRouter} />
 );


### PR DESCRIPTION
## Problem
A common issue in `single-page applications` (SPAs) where the scroll position is maintained when navigating between different views or components. This is an issue since when react loads a different component on the same page and I have scrolled down to bottom the page will show bottom feed.

## Solution

This PR fixes the issue using the `<ScrollRestoration />` Component from the `react-router-dom` library. It restores the page scroll position back to the top.